### PR TITLE
Bugfix: Set prev ball positions to off before drawing new ones

### DIFF
--- a/BouncingBalls/BouncingBalls.ino
+++ b/BouncingBalls/BouncingBalls.ino
@@ -71,6 +71,9 @@ void loop() {
     for (int i = 0; i < endP; i++) {
       Particle *p = &particles[i];
       cal_lights.setLED((int) p->pre.x, (int) p->pre.y, false);
+    }
+    for (int i = 0; i < endP; i++) {
+      Particle *p = &particles[i];
       cal_lights.setLED((int) p->pos.x, (int) p->pos.y, true);
       p->pre.x = p->pos.x;
       p->pre.y = p->pos.y;


### PR DESCRIPTION
Hi!

I noticed this bug when I was watching the livestream. Imagine there are two balls, just for the fun of it I'm going to call them Alice and Bob.

Time 1:
Alice is at 3, 3 and has a velocity of 1, 1
LED 3,3 turned off
LED 3,3 turned on
Bob is at 4, 4 and has a velocity of 1, 1
LED 4,4 turned off
LED 4,4 turned on
---------------------
LEDs at 3,3 and 4,4 are on

Time 2:
Alice is at 4, 4 and has a velocity of ...(irrelevant)
LED 3,3 turned off (prev pos)
LED 4,4 turned on
Bob is at 5, 5 and has a velocity of ...(irr.)
LED 4,4 turned off (prev pos)
LED 5,5 turned on
---------------------
Only the LED at 5,5 is on

The problem is that if there is a ball(Alice) following another ball(Bob) and its index is smaller than the other one(i.e. processed before Bob), the ball in the front(Bob) turns off the one in the back(Alice).

This is a small and quick fix, and there might be a better way to this.

Cheers!

